### PR TITLE
Do not fail on versionAlreadyExists if !environmentName

### DIFF
--- a/beanstalk-deploy.js
+++ b/beanstalk-deploy.js
@@ -368,7 +368,7 @@ function main() {
         if (versionAlreadyExists) {
 
             if (!environmentName) {
-                console.log(`You have no environment set, so we are trying to only create version ${versionLabel}, but it already exists in Beanstalk!`);
+                console.log(`No environment set, but the version ${versionLabel} was found - exiting successfully with no change`);
                 process.exit(0);
             } else if (file && !useExistingVersionIfAvailable) {
                 console.error(`Deployment failed: Version ${versionLabel} already exists. Either remove the "deployment_package" parameter to deploy existing version, or set the "use_existing_version_if_available" parameter to "true" to use existing version if it exists and deployment package if it doesn't.`);

--- a/beanstalk-deploy.js
+++ b/beanstalk-deploy.js
@@ -368,8 +368,8 @@ function main() {
         if (versionAlreadyExists) {
 
             if (!environmentName) {
-                console.error(`You have no environment set, so we are trying to only create version ${versionLabel}, but it already exists in Beanstalk!`);
-                process.exit(2);
+                console.log(`You have no environment set, so we are trying to only create version ${versionLabel}, but it already exists in Beanstalk!`);
+                process.exit(0);
             } else if (file && !useExistingVersionIfAvailable) {
                 console.error(`Deployment failed: Version ${versionLabel} already exists. Either remove the "deployment_package" parameter to deploy existing version, or set the "use_existing_version_if_available" parameter to "true" to use existing version if it exists and deployment package if it doesn't.`);
                 process.exit(2);


### PR DESCRIPTION
This repository is a fork of https://github.com/einaregilsson/beanstalk-deploy. @n-hebert and I want to experiment and see if we can overcome deployments failing due to existing application versions when using matrix builds with these simple changes.