### PR TITLE
Make max retries configurable and increase potential jitter

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ the version but not deploy it anywhere.
 *It will prevent the action from (re)creating a bucket during deployment as well.*
 Omit this parameter to have the action create the bucket. The latter requires the API key used to have the applicable permissions. 
 
+`max_backoff_retries` *(since v21)*: Use this if you have a heavy load environment and need more than 10 exponential back-off retries.
+10 retries is about 1m at its maximum.
+
 ### AWS Permissions
 
 It should be enough for your AWS user to have the policies **AWSElasticBeanstalkWebTier** and **AWSElasticBeanstalkManagedUpdatesCustomerRolePolicy** attached 

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,9 @@ inputs:
   wait_for_environment_recovery:
     description: 'How many seconds to wait for the environment to return to Green state after deployment is finished. Default is 30 seconds.'
     required: false
+  max_backoff_retries:
+    description: 'How many times to exponentially back-off on Throttling exceptions. Default: 10'
+    required: false
 
 branding:
   icon: 'arrow-up'  

--- a/aws-api-request.js
+++ b/aws-api-request.js
@@ -9,6 +9,7 @@ function awsApiRequest(options, retryAttempt = 0) {
             accessKey = options.accessKey || awsApiRequest.accessKey || process.env.AWS_ACCESS_KEY_ID,
             secretKey = options.secretKey || awsApiRequest.secretKey || process.env.AWS_SECRET_ACCESS_KEY,
             sessionToken = options.sessionToken || awsApiRequest.sessionToken || process.env.AWS_SESSION_TOKEN,
+            maxBackoffRetries =  options.maxBackoffRetries || awsApiRequest.maxBackoffRetries || 10,
             method = options.method || 'GET',
             path = options.path || '/',
             querystring = options.querystring || {},
@@ -109,8 +110,6 @@ function awsApiRequest(options, retryAttempt = 0) {
 
         reqHeaders.Authorization = authHeader;
 
-        const MAX_RETRY_COUNT = 10;
-
         //Now, lets finally do a HTTP REQUEST!!!
         request(method, encodeURI(path), reqHeaders, querystring, payload, retryAttempt, (err, result) => {
             if (err) {
@@ -138,7 +137,7 @@ function awsApiRequest(options, retryAttempt = 0) {
                     //2~8 * 100 = 25600
                     //2~9 * 100 = 51200
 
-                    if (retryAttempt > MAX_RETRY_COUNT) {
+                    if (retryAttempt > maxBackoffRetries) {
                         //Give them the error result, the caller can then deal with it...
                         console.warn(`Retry attempt exceeded max retry count (${MAX_RETRY_COUNT})... Giving up...`);
                         resolve(result);

--- a/aws-api-request.js
+++ b/aws-api-request.js
@@ -123,8 +123,8 @@ function awsApiRequest(options, retryAttempt = 0) {
                         host: url.hostname
                     }));
                 } else if (wasThrottled(result)) {
-                    //Exponential backoff with a 500ms jitter
-                    let timeout = Math.pow(2, retryAttempt) * 100 + Math.floor(Math.random() * 500);
+                    //Exponential backoff with a 2000ms jitter
+                    let timeout = Math.pow(2, retryAttempt) * 100 + Math.floor(Math.random() * 2000);
                     //Exponential backoff...
                     //2~0 * 100 = 100
                     //2~1 * 100 = 200

--- a/beanstalk-deploy.js
+++ b/beanstalk-deploy.js
@@ -265,6 +265,7 @@ function main() {
         versionDescription = strip(process.env.INPUT_VERSION_DESCRIPTION);
         file = strip(process.env.INPUT_DEPLOYMENT_PACKAGE);
 
+        awsApiRequest.maxBackoffRetries = strip(process.env.INPUT_MAX_BACKOFF_RETRIES);
         awsApiRequest.accessKey = strip(process.env.INPUT_AWS_ACCESS_KEY);
         awsApiRequest.secretKey = strip(process.env.INPUT_AWS_SECRET_KEY);
         awsApiRequest.sessionToken = strip(process.env.INPUT_AWS_SESSION_TOKEN);


### PR DESCRIPTION
As on the title.

We need more horse-power in terms of back-off. This makes it configurable.
We also want to ungroup jobs from being in the same second as much as is reasonable, so a 2s jitter increases the likelihood that they do not all continuously poll on the same second. More-so each round.